### PR TITLE
prevent setting up multiple countdowns

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -68,6 +68,8 @@ async function createReminderDialog() {
     const timerSelection = dialog.querySelector('#timer-selection');
 
     dialog.querySelector('.schedule').addEventListener('click', () => {
+        if (countdownInterval) clearInterval(countdownInterval);
+
         let timeLeft = DELAY_TIME;
         timerSelection.style.display = 'none';
         timerDisplay.style.display = 'block';


### PR DESCRIPTION
I've discovered that clicking "Take a Break" button multiple times would span multiple countdowns and result in strange countdown behavior so I've fixed that.